### PR TITLE
Fix build with dune 3.6

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -12,7 +12,7 @@
   (vendored
     ; hack: multiple -I directives to work around cc commands being run from
     ; different relative directories.  Is there a cleaner way to do this?
-    (c_flags ("-Ilib" "-I."))))
+    (c_flags :standard "-Ilib" "-I.")))
   (headers (include "hdr_histogram.h"))
   (type_description
    (instance Type)


### PR DESCRIPTION
Releasing dune 3.6 revealed a regression on `hdr_histogram` (it builds with 3.5 but not 3.6). After investigating, it seems to be an issue with the dune file in `hdr_histogram`: `:standard` was missing from the `(c_flags)` field. Adding it ensures this build with 3.6 too.

References:

- <https://github.com/ocaml/opam-repository/pull/22498>
- <https://github.com/ocaml/dune/issues/6481>
