### PR TITLE
Remove ctypes include path hack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## dev
+
+* Remove ctypes include path hack by using ctypes 0.3 / dune 3.7 (@TheLortex, #5)
+
 ## v0.0.3 (2023-02-17)
 
 * Add memory_size function (@crackcomm, #1)

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 3.3)
-(using ctypes 0.1)
+(lang dune 3.7)
+(using ctypes 0.3)
 
 (name hdr_histogram)
 

--- a/hdr_histogram.opam
+++ b/hdr_histogram.opam
@@ -11,7 +11,7 @@ doc: "https://ocaml-multicore.github.io/hdr_histogram_ocaml"
 bug-reports: "https://github.com/ocaml-multicore/hdr_histogram_ocaml/issues"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {>= "3.3"}
+  "dune" {>= "3.7"}
   "ctypes" {>= "0.20.1"}
   "ctypes-foreign" {>= "0.18.0"}
   "conf-pkg-config" {build}

--- a/lib/dune
+++ b/lib/dune
@@ -11,9 +11,7 @@
   (deps hdr_histogram.h dllhdr_histogram.so libhdr_histogram.a)
   (build_flags_resolver
    (vendored
-    ; hack: multiple -I directives to work around cc commands being run from
-    ; different relative directories.  Is there a cleaner way to do this?
-    (c_flags :standard "-Ilib" "-I.")))
+    (c_flags :standard "-I.")))
   (headers
    (include "hdr_histogram.h"))
   (type_description


### PR DESCRIPTION
This enables using hdr_histogram_ocaml in a monorepo. 

Thanks to https://github.com/ocaml/dune/pull/6883 (merged in dune 3.7), the ctypes rule is interpreted in the folder where it is defined. This means we can use relative paths and everything works as expected.  
