### PR TITLE
Fix FreeBSD support.

### DIFF
--- a/lib/libhdr_histogram/src/hdr_endian.h
+++ b/lib/libhdr_histogram/src/hdr_endian.h
@@ -40,11 +40,11 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 
 #	include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__)
 
 #	include <sys/endian.h>
 

--- a/lib/libhdr_histogram/src/hdr_time.c
+++ b/lib/libhdr_histogram/src/hdr_time.c
@@ -62,8 +62,7 @@ void hdr_getnow(hdr_timespec* ts)
     hdr_gettime(ts);
 }
 
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__)
-
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 void hdr_gettime(hdr_timespec* t)
 {


### PR DESCRIPTION
Fix for https://github.com/ocaml-multicore/hdr_histogram_ocaml/issues/6.

Tested on FreeBSD 13.2 manually and on https://ocaml.ci.dev/github/tmcgilchrist/hdr_histogram_ocaml/commit/df44d09e1682c3b8863dcb50c2329ee2602cf20f

I don't have access to DragonFly BSD to validate. 