### PR TITLE
Do not release runtime lock when recording values : 1.8x faster value recording

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -18,7 +18,7 @@
    (instance Type)
    (functor Type_description))
   (function_description
-   (concurrency unlocked)
+   (concurrency sequential)
    (instance Function)
    (functor Function_description))
   (generated_types Types_generated)


### PR DESCRIPTION
Unfortunately we can only control concurrency mode for the entire library.

But we should not release the runtime lock in 'record_value', because that would:

- introduce additional overhead in the form of a potential context switch to another thread (perhaps fundamentally altering the behaviour of the application that we're trying to observe)

- it is not necessary because recording the value is supposed to take nanoseconds

A measurement on `test1.ml` shows a significant speedup:
```
Benchmark 1: ./old.exe
  Time (mean ± σ):      4.485 s ±  0.032 s    [User: 4.467 s, System: 0.002 s]
  Range (min … max):    4.411 s …  4.510 s    10 runs

Benchmark 2: ./new.exe
  Time (mean ± σ):      2.425 s ±  0.003 s    [User: 2.414 s, System: 0.002 s]
  Range (min … max):    2.422 s …  2.430 s    10 runs

Summary
  ./new.exe ran
    1.85 ± 0.01 times faster than ./old.exe
```